### PR TITLE
fixed issue when surgeon_id was not presented

### DIFF
--- a/views/default/update.php
+++ b/views/default/update.php
@@ -34,9 +34,7 @@ $this->beginContent('//patient/event_container', array());
 					<div class="data-label" style="margin-top: 1rem;">Surgeon:</div>
 				</div>
 				<div class="large-9 column end">
-					<div class="data-value"  style="margin-top: 1rem;">&nbsp;&nbsp;<b><?php echo (OphInBiometry_Surgeon::model()->findByAttributes(
-								array('id' => Element_OphInBiometry_IolRefValues::model()->findByAttributes(array('event_id' => $this->event->id))->surgeon_id)
-							)->name); ?></b></div>
+					<div class="data-value"  style="margin-top: 1rem;">&nbsp;&nbsp;<b><?php echo OphInBiometry_Imported_Events::model()->findByAttributes(array('event_id' => $this->event->id))->surgeon_name; ?></b></div>
 				</div>
 			</div>
 			<?php

--- a/views/default/view.php
+++ b/views/default/view.php
@@ -33,9 +33,7 @@ if($this->is_auto) {
 		<div class="data-label">Surgeon:</div>
 	</div>
 	<div class="large-9 column end">
-		<div class="data-value"><b><?php echo (OphInBiometry_Surgeon::model()->findByAttributes(
-					array('id' => Element_OphInBiometry_IolRefValues::model()->findByAttributes(array('event_id' => $this->event->id))->surgeon_id)
-				)->name); ?></b></div>
+		<div class="data-value"><b><?php echo  OphInBiometry_Imported_Events::model()->findByAttributes(array('event_id' => $this->event->id))->surgeon_name; ?></b></div>
 	</div>
 </div>
 <?php


### PR DESCRIPTION
we still save the surgeon name as string to the imported events table because we not always have IOLREF values
we can have more then 1 row in IOLREF values, so surgeon should be a drop-down
